### PR TITLE
若干小问题的修正

### DIFF
--- a/battle.c
+++ b/battle.c
@@ -1440,7 +1440,7 @@ PAL_StartBattle(
    PAL_ClearAllPlayerStatus();
    for (w = 0; w < MAX_PLAYER_ROLES; w++)
    {
-      PAL_CurePoisonByLevel(w, 3);
+      PAL_CurePoisonByLevel(w, MAX_POISON_LEVEL);
       PAL_RemoveEquipmentEffect(w, kBodyPartExtra);
    }
 

--- a/common.h
+++ b/common.h
@@ -22,7 +22,9 @@
 #define _COMMON_H
 
 //#define PAL_WIN95          1 // not valid for now
-//#define PAL_CLASSIC        1
+#define PAL_CLASSIC        1
+
+#define MAX_POISON_LEVEL					99		//复活后解除的毒的最高等级；99一般为装备技能，如寿葫芦
 
 #ifdef __cplusplus
 extern "C"

--- a/fight.c
+++ b/fight.c
@@ -43,7 +43,8 @@ PAL_IsPlayerDying(
 
 --*/
 {
-   return gpGlobals->g.PlayerRoles.rgwHP[wPlayerRole] < gpGlobals->g.PlayerRoles.rgwMaxHP[wPlayerRole] / 5;
+   return gpGlobals->g.PlayerRoles.rgwHP[wPlayerRole] < gpGlobals->g.PlayerRoles.rgwMaxHP[wPlayerRole] / 5
+	   && gpGlobals->g.PlayerRoles.rgwHP[wPlayerRole] < 100;      // 还需要低于100
 }
 
 INT
@@ -1555,6 +1556,20 @@ PAL_BattleStartFrame(
          {
             wPlayerRole = gpGlobals->rgParty[i].wPlayerRole;
 
+
+			//
+			// Update statuses
+			// 更新状态应在执行中毒脚本前
+			for (j = 0; j < kStatusAll; j++)
+			{
+				if (gpGlobals->rgPlayerStatus[wPlayerRole][j] > 0)
+				{
+					gpGlobals->rgPlayerStatus[wPlayerRole][j]--;
+				}
+			}
+
+			// 执行中毒脚本前、后都需要排序
+			PAL_New_SortPoisonsForPlayerByLevel(wPlayerRole);
             for (j = 0; j < MAX_POISONS; j++)
             {
                if (gpGlobals->rgPoisonStatus[j][i].wPoisonID != 0)
@@ -1563,17 +1578,7 @@ PAL_BattleStartFrame(
                      PAL_RunTriggerScript(gpGlobals->rgPoisonStatus[j][i].wPoisonScript, wPlayerRole);
                }
             }
-
-            //
-            // Update statuses
-            //
-            for (j = 0; j < kStatusAll; j++)
-            {
-               if (gpGlobals->rgPlayerStatus[wPlayerRole][j] > 0)
-               {
-                  gpGlobals->rgPlayerStatus[wPlayerRole][j]--;
-               }
-            }
+			PAL_New_SortPoisonsForPlayerByLevel(wPlayerRole);
          }
 
          for (i = 0; i <= g_Battle.wMaxEnemyIndex; i++)

--- a/global.c
+++ b/global.c
@@ -1889,3 +1889,49 @@ PAL_PlayerLevelUp(
    gpGlobals->Exp.rgPrimaryExp[wPlayerRole].wLevel =
       gpGlobals->g.PlayerRoles.rgwLevel[wPlayerRole];
 }
+
+VOID
+PAL_New_SortPoisonsForPlayerByLevel(
+	WORD			wPlayerRole
+	)
+{
+	int         i, j, index, PoisonNum;
+	WORD        wPoisonID1, wPoisonID2;
+	WORD        wPoisonLevel1, wPoisonLevel2;
+	POISONSTATUS	tempPoison;
+
+	for (index = 0; index <= gpGlobals->wMaxPartyMemberIndex; index++)
+	{
+		if (gpGlobals->rgParty[index].wPlayerRole == wPlayerRole)break;
+	}
+
+	if (index > gpGlobals->wMaxPartyMemberIndex)return; // don't go further
+
+	for (j = 0, PoisonNum = 0; j < MAX_POISONS; j++)
+	{
+		wPoisonID1 = gpGlobals->rgPoisonStatus[j][index].wPoisonID;
+		if (wPoisonID1 == 0) gpGlobals->rgPoisonStatus[j][index].wPoisonScript = 0;
+		else PoisonNum++;
+	}
+
+	if (PoisonNum < 2)	return;	//中毒数目小于2不用排序
+
+
+	for (i = 0; i < MAX_POISONS - 1; i++)
+	{
+		for (j = 0; j < MAX_POISONS - i - 1; j++)
+		{
+			wPoisonID1 = gpGlobals->rgPoisonStatus[j][index].wPoisonID;
+			wPoisonLevel1 = gpGlobals->g.rgObject[wPoisonID1].poison.wPoisonLevel;
+			wPoisonID2 = gpGlobals->rgPoisonStatus[j + 1][index].wPoisonID;
+			wPoisonLevel2 = gpGlobals->g.rgObject[wPoisonID2].poison.wPoisonLevel;
+
+			if (wPoisonLevel1 < wPoisonLevel2)
+			{
+				tempPoison = gpGlobals->rgPoisonStatus[j][index];
+				gpGlobals->rgPoisonStatus[j][index] = gpGlobals->rgPoisonStatus[j + 1][index];
+				gpGlobals->rgPoisonStatus[j + 1][index] = tempPoison;
+			}
+		}
+	}
+}

--- a/global.h
+++ b/global.h
@@ -770,6 +770,11 @@ PAL_PlayerLevelUp(
    WORD          wNumLevel
 );
 
+VOID 
+PAL_New_SortPoisonsForPlayerByLevel(
+	WORD wPlayerRole
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/script.c
+++ b/script.c
@@ -1028,7 +1028,7 @@ PAL_InterpretInstruction(
                gpGlobals->g.PlayerRoles.rgwHP[w] =
                   gpGlobals->g.PlayerRoles.rgwMaxHP[w] * pScript->rgwOperand[1] / 10;
 
-               PAL_CurePoisonByLevel(w, 3);
+               PAL_CurePoisonByLevel(w, MAX_POISON_LEVEL);
                for (x = 0; x < kStatusAll; x++)
                {
                   PAL_RemovePlayerStatus(w, x);


### PR DESCRIPTION
把战后解毒的最高等级设置为一个宏（原来是3，这不合理）；
判断角色濒死的条件（与原版保持一致）；
增加把角色中的毒的排序（与原版保持一致，为了使各个毒的中毒脚本的执行顺序明确，即按照毒等级排列，先执行等级高的）；
更新角色状态应在执行中毒脚本前（与原版保持一致）；
