### PR TITLE
通过造表查表方式改进ColorShift操作，提高性能

### DIFF
--- a/battle.c
+++ b/battle.c
@@ -52,29 +52,18 @@ PAL_BattleMakeScene(
    int          i;
    PAL_POS      pos;
    LPBYTE       pSrc, pDst;
-   BYTE         b;
+   BYTE         shifttable[256];
 
    //
    // Draw the background
    //
    pSrc = g_Battle.lpBackground->pixels;
    pDst = g_Battle.lpSceneBuf->pixels;
+   PAL_MakeColorShiftTable(shifttable, g_Battle.sBackgroundColorShift);
 
    for (i = 0; i < g_Battle.lpSceneBuf->pitch * g_Battle.lpSceneBuf->h; i++)
    {
-      b = (*pSrc & 0x0F);
-      b += g_Battle.sBackgroundColorShift;
-
-      if (b & 0x80)
-      {
-         b = 0;
-      }
-      else if (b & 0x70)
-      {
-         b = 0x0F;
-      }
-
-      *pDst = (b | (*pSrc & 0xF0));
+      *pDst = shifttable[*pSrc];
 
       ++pSrc;
       ++pDst;

--- a/palcommon.c
+++ b/palcommon.c
@@ -184,7 +184,8 @@ PAL_RLEBlitWithColorShift(
    UINT          uiLen       = 0;
    UINT          uiWidth     = 0;
    UINT          uiHeight    = 0;
-   BYTE          T, b;
+   BYTE          T;
+   BYTE          shifttable[256];
    INT           dx          = PAL_X(pos);
    INT           dy          = PAL_Y(pos);
 
@@ -220,6 +221,7 @@ PAL_RLEBlitWithColorShift(
    //
    // Start decoding and blitting the bitmap.
    //
+   PAL_MakeColorShiftTable(shifttable, (SHORT)iColorShift);
    lpBitmapRLE += 4;
    for (i = 0; i < uiLen;)
    {
@@ -266,22 +268,9 @@ PAL_RLEBlitWithColorShift(
             //
             // Put the pixel onto the surface (FIXME: inefficient).
             //
-            b = (lpBitmapRLE[j] & 0x0F);
-            if ((INT)b + iColorShift > 0x0F)
-            {
-               b = 0x0F;
-            }
-            else if ((INT)b + iColorShift < 0)
-            {
-               b = 0;
-            }
-            else
-            {
-               b += iColorShift;
-            }
 
             ((LPBYTE)lpDstSurface->pixels)[y * lpDstSurface->pitch + x] =
-               (b | (lpBitmapRLE[j] & 0xF0));
+               shifttable[lpBitmapRLE[j]];
          }
          lpBitmapRLE += T;
          i += T;
@@ -931,4 +920,47 @@ PAL_MKFDecompressChunk(
    free(buf);
 
    return len;
+}
+
+
+VOID
+PAL_MakeColorShiftTable(
+   LPBYTE            lpTable,
+   SHORT             iColorShift
+)
+/*++
+  Purpose:
+
+    Make a color shift table, to speed up futher color shift operations.
+
+  Parameters:
+
+    [OUT] lpTable - pointer to the table, an array of exactly 256 bytes.
+
+    [IN]  iColorShift - shift the color by this value.
+
+  Return value:
+
+    None.
+
+--*/
+{
+   UINT   i;
+   BYTE   b;
+   for (i = 0; i < 256; i++) {
+      b = ((BYTE)i & 0x0F);
+
+      b += iColorShift;
+
+      if (b & 0x80)
+      {
+         b = 0;
+      }
+      else if (b & 0x70)
+      {
+         b = 0x0F;
+      }
+
+      lpTable[i] = (b | ((BYTE)i & 0xF0));
+   }
 }

--- a/palcommon.h
+++ b/palcommon.h
@@ -131,6 +131,12 @@ PAL_MKFDecompressChunk(
    FILE           *fp
 );
 
+VOID
+PAL_MakeColorShiftTable(
+   LPBYTE            lpTable,
+   SHORT             iColorShift
+);
+
 // From yj1.c:
 INT
 Decompress(


### PR DESCRIPTION
之前的代码执行ColorShift的方式是，在循环内部对每一个像素的颜色进行判断、位运算得到结果。改进后的代码先对所有可能的256种颜色进行预处理，得到一张表，然后再在循环内部对每一个像素查表得到结果。这样在循环内部只需执行访存指令，不需要进行判断、位运算等，速度较快。

这个改进在速度很慢的机器上（例如[NEMU虚拟机](https://github.com/nju-ics/ics2016)）效果很明显，ColorShift操作可以获得3-5倍的性能提升。